### PR TITLE
Set default registry to quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ objectstorage-controller-6fc5f89444-4ws72   1/1     Running   0          2d6h
 
 ## Building
 
-the driver's code can be compiled using:
+the driver code can be compiled using:
 
 ```shell
 make build
 ```
 
-Now build the docker image and provide a tag as `ghcr.io/giubacc/s3gw-cosi-driver:latest`
+Now build the docker image and provide a tag as `quay.io/s3gw/s3gw-cosi-driver:latest`
 
 ```shell
 $ make container
@@ -34,8 +34,8 @@ Sending build context to Docker daemon  41.95MB
 You can tag and push the docker image to a registry with:
 
 ```shell
-docker tag s3gw-cosi-driver:latest ghcr.io/giubacc/s3gw-cosi-driver:latest
-docker push ghcr.io/giubacc/s3gw-cosi-driver:latest
+docker tag s3gw-cosi-driver:latest quay.io/s3gw/s3gw-cosi-driver:latest
+docker push quay.io/s3gw/s3gw-cosi-driver:latest
 ```
 
 ## Installing with Helm

--- a/charts/s3gw-cosi/templates/_helpers.tpl
+++ b/charts/s3gw-cosi/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Version helpers for the driver image tag
 {{- $defaulttag := printf "%s" "latest" }}
 {{- $tag := default $defaulttag .Values.driver.imageTag }}
 {{- $name := default "s3gw-cosi-driver" .Values.driver.imageName }}
-{{- $registry := default "ghcr.io/giubacc" .Values.driver.imageRegistry }}
+{{- $registry := default "quay.io/s3gw" .Values.driver.imageRegistry }}
 {{- printf "%s/%s:%s" $registry $name $tag }}
 {{- end }}
 
@@ -70,7 +70,7 @@ Version helpers for the sidecar image tag
 {{- define "s3gw-cosi.sidecarImage" -}}
 {{- $defaulttag := printf "%s" "latest" }}
 {{- $tag := default $defaulttag .Values.sidecar.imageTag }}
-{{- $name := default "objectstorage-sidecar" .Values.sidecar.imageName }}
-{{- $registry := default "ghcr.io/giubacc" .Values.sidecar.imageRegistry }}
+{{- $name := default "s3gw-cosi-sidecar" .Values.sidecar.imageName }}
+{{- $registry := default "quay.io/s3gw" .Values.sidecar.imageRegistry }}
 {{- printf "%s/%s:%s" $registry $name $tag }}
 {{- end }}


### PR DESCRIPTION
The default registry has been uniformed with the rest of s3gw project to be quay.io

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
