### PR TITLE
Make driver name parametric

### DIFF
--- a/cmd/s3gw-cosi-driver/cmd.go
+++ b/cmd/s3gw-cosi-driver/cmd.go
@@ -30,13 +30,12 @@ import (
 	"sigs.k8s.io/container-object-storage-interface-provisioner-sidecar/pkg/provisioner"
 )
 
-const provisionerName = "s3gw.objectstorage.k8s.io"
-
 var (
-	driverAddress = "unix:///var/lib/cosi/cosi.sock"
-	AccessKey     = ""
-	SecretKey     = ""
-	Endpoint      = ""
+	ProvisionerName = "s3gw.objectstorage.k8s.io"
+	driverAddress   = "unix:///var/lib/cosi/cosi.sock"
+	AccessKey       = ""
+	SecretKey       = ""
+	Endpoint        = ""
 )
 
 var cmd = &cobra.Command{
@@ -62,6 +61,12 @@ func init() {
 	persistentFlags.AddGoFlagSet(kflags)
 
 	stringFlag := persistentFlags.StringVarP
+
+	stringFlag(&ProvisionerName,
+		"drivername",
+		"n",
+		driverAddress,
+		"driver name")
 
 	stringFlag(&driverAddress,
 		"driver-addr",
@@ -98,7 +103,7 @@ func init() {
 
 func run(ctx context.Context, args []string) error {
 	identityServer, bucketProvisioner, err := driver.NewDriver(ctx,
-		provisionerName,
+		ProvisionerName,
 		Endpoint,
 		AccessKey,
 		SecretKey)


### PR DESCRIPTION
The driver's name can be set through a parameter or an environment variable.

Parameter name:
	- drivername
	- n (shorthand)

Environment variable name:
	- drivername (case insensitive)

The default driver's name is: s3gw.objectstorage.k8s.io

Related to: https://github.com/aquarist-labs/s3gw/issues/438
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

# Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
