### PR TITLE
fix: spaces in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ build:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ./bin/s3gw-cosi-driver ./cmd/*
 
 test:
-  mkdir -p bin
-  CGO_ENABLED=0 GOOS=linux go test ./cmd/*
+	mkdir -p bin
+	CGO_ENABLED=0 GOOS=linux go test ./cmd/*
 
 container:
 	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile .


### PR DESCRIPTION
Fix spaces in Makefile. They must be tabs, or `make` will be sad.

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
